### PR TITLE
Multi distro travis

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,12 +1,1 @@
-- git:
-    uri: 'https://github.com/ipa320/cob_command_tools.git'
-    local-name: cob_command_tools
-    version: indigo_dev
-- git:
-    uri: 'https://github.com/ipa320/cob_common.git'
-    local-name: cob_common
-    version: indigo_dev
-- git:
-    uri: 'https://github.com/ipa320/cob_driver.git'
-    local-name: cob_driver
-    version: indigo_dev
+# no overlays needed

--- a/.travis.rosinstall.jade
+++ b/.travis.rosinstall.jade
@@ -1,0 +1,1 @@
+.travis.rosinstall.kinetic

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,0 +1,20 @@
+- git:
+    uri: 'https://github.com/ipa320/cob_command_tools.git'
+    local-name: cob_command_tools
+    version: indigo_dev
+- git:
+    uri: 'https://github.com/ipa320/cob_common.git'
+    local-name: cob_common
+    version: indigo_dev
+- git:
+    uri: 'https://github.com/ipa320/cob_driver.git'
+    local-name: cob_driver
+    version: indigo_dev
+- git:
+    uri: 'https://github.com/ipa320/cob_extern.git'
+    local-name: cob_extern
+    version: indigo_dev
+- git:
+    uri: 'https://github.com/ipa320/cob_perception_common.git'
+    local-name: cob_perception_common
+    version: indigo_dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file
+    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: required 
-dist: trusty 
+sudo: required
+dist: trusty
 language: generic
 notifications:
   email:
@@ -7,12 +7,16 @@ notifications:
     on_failure: always
 env:
   global:
-    - ROS_DISTRO="indigo"
     - UPSTREAM_WORKSPACE=file
-    - ROSINSTALL_FILENAME=.travis.rosinstall
   matrix:
-    - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu UPSTREAM_WORKSPACE=file
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: .ci_config/travis.sh
-#  - source ./travis.sh  # Enable this when you have a package-local script 
+script:
+  - .ci_config/travis.sh
+#  - ./travis.sh  # Enable this when you have a package-local script 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
-Travis-CI: [![Build Status](https://travis-ci.org/ipa320/cob_android.svg?branch=indigo_dev)](https://travis-ci.org/ipa320/cob_android)
-
 cob_android
 ===========
+
+## ROS Distro Support
+
+|         | Indigo | Jade | Kinetic |
+|:-------:|:------:|:----:|:-------:|
+| Branch  | [`indigo_dev`](https://github.com/ipa320/cob_android/tree/indigo_dev) | [`indigo_dev`](https://github.com/ipa320/cob_android/tree/indigo_dev) | [`indigo_dev`](https://github.com/ipa320/cob_android/tree/indigo_dev) |
+| Status  |  supported | not supported |  supported |
+| Version | [version](http://repositories.ros.org/status_page/ros_indigo_default.html?q=cob_android) | [version](http://repositories.ros.org/status_page/ros_jade_default.html?q=cob_android) | [version](http://repositories.ros.org/status_page/ros_kinetic_default.html?q=cob_android) |
+
+## Travis - Continuous Integration
+
+Status: [![Build Status](https://travis-ci.org/ipa320/cob_android.svg?branch=indigo_dev)](https://travis-ci.org/ipa320/cob_android)
+
+## ROS Buildfarm
+
+|         | Indigo Source | Indigo Debian | Jade Source | Jade Debian |  Kinetic Source  |  Kinetic Debian |
+|:-------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|:-------------------:|
+| cob_android | [![not released](http://build.ros.org/buildStatus/icon?job=Isrc_uT__cob_android__ubuntu_trusty__source)](http://build.ros.org/view/Isrc_uT/job/Isrc_uT__cob_android__ubuntu_trusty__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Ibin_uT64__cob_android__ubuntu_trusty_amd64__binary)](http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__cob_android__ubuntu_trusty_amd64__binary/) | [![not released](http://build.ros.org/buildStatus/icon?job=Jsrc_uT__cob_android__ubuntu_trusty__source)](http://build.ros.org/view/Jsrc_uT/job/Jsrc_uT__cob_android__ubuntu_trusty__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Jbin_uT64__cob_android__ubuntu_trusty_amd64__binary)](http://build.ros.org/view/Jbin_uT64/job/Jbin_uT64__cob_android__ubuntu_trusty_amd64__binary/) | [![not released](http://build.ros.org/buildStatus/icon?job=Ksrc_uX__cob_android__ubuntu_xenial__source)](http://build.ros.org/view/Ksrc_uX/job/Ksrc_uX__cob_android__ubuntu_xenial__source/) | [![not released](http://build.ros.org/buildStatus/icon?job=Kbin_uX64__cob_android__ubuntu_xenial_amd64__binary)](http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__cob_android__ubuntu_xenial_amd64__binary/) |


### PR DESCRIPTION
`cob_android` is a candidate for indigo/kinetic-compatible `indigo_dev` branch, i.e. `kinetic_dev` should be removed

I'm experimenting with the travis.yml in order to set up proper "multi-distro" CI...
@ipa-mdl @ipa-bnm FYI