### PR TITLE
fix install tags for indigo

### DIFF
--- a/cob_android_script_server/CMakeLists.txt
+++ b/cob_android_script_server/CMakeLists.txt
@@ -10,3 +10,7 @@ catkin_package()
 install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+install(PROGRAMS scripts/script_server_android
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}/scripts
+)


### PR DESCRIPTION
this seems to have changes in kinetic recently

travis jobs are crashing due to not installed executable
- https://travis-ci.org/ipa320/cob_robots/jobs/240757408
- https://travis-ci.org/ipa320/cob_robots/jobs/240237971

in indigo it seems to be ok to only mention the script in the `setup.py`. somehow in kinetic this needs to be explicitly installed. @ipa-bnm @ipa-mdl does this make sense?