### PR TITLE
use license apache 2.0

### DIFF
--- a/cob_android/package.xml
+++ b/cob_android/package.xml
@@ -3,7 +3,7 @@
   <version>0.1.2</version>
   <description>cob_android package provides tools for android apps operation.</description>
  
-  <license>LGPL</license>
+  <license>Apache 2.0</license>
 
   <url type="website">http://ros.org/wiki/cob_android</url>
 

--- a/cob_android_msgs/package.xml
+++ b/cob_android_msgs/package.xml
@@ -3,7 +3,7 @@
   <version>0.1.2</version>
   <description>cob_android_msgs</description>
   
-  <license>LGPL</license>
+  <license>Apache 2.0</license>
 
   <url type="website">http://ros.org/wiki/cob_android_msgs</url>
 

--- a/cob_android_resource_server/package.xml
+++ b/cob_android_resource_server/package.xml
@@ -3,7 +3,7 @@
   <version>0.1.2</version>
   <description>cob_android_resource_server</description>
   
-  <license>LGPL</license>
+  <license>Apache 2.0</license>
 
   <url type="website">http://ros.org/wiki/cob_android_resource_server</url>
 

--- a/cob_android_resource_server/scripts/resource_server
+++ b/cob_android_resource_server/scripts/resource_server
@@ -1,3 +1,19 @@
 #!/usr/bin/env python
+#
+# Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import cob_android_resource_server.resource_server
 cob_android_resource_server.resource_server.resource_server_main()

--- a/cob_android_resource_server/src/cob_android_resource_server/resource_server.py
+++ b/cob_android_resource_server/src/cob_android_resource_server/resource_server.py
@@ -1,4 +1,19 @@
-#! /usr/bin/python
+#!/usr/bin/env python
+#
+# Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 from os import path

--- a/cob_android_script_server/package.xml
+++ b/cob_android_script_server/package.xml
@@ -3,7 +3,7 @@
   <version>0.1.2</version>
   <description>cob_android_script_server</description>
   
-  <license>LGPL</license>
+  <license>Apache 2.0</license>
 
   <url type="website">http://ros.org/wiki/cob_android_script_server</url>
 

--- a/cob_android_script_server/scripts/script_server_android
+++ b/cob_android_script_server/scripts/script_server_android
@@ -1,3 +1,19 @@
 #!/usr/bin/env python
+#
+# Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import cob_android_script_server.script_server_android
 cob_android_script_server.script_server_android.script_server_android_main()

--- a/cob_android_script_server/src/cob_android_script_server/script_server_android.py
+++ b/cob_android_script_server/src/cob_android_script_server/script_server_android.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python
+#
+# Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import time
 import inspect
 

--- a/cob_android_settings/package.xml
+++ b/cob_android_settings/package.xml
@@ -3,7 +3,7 @@
   <version>0.1.2</version>
   <description>cob_android_settings</description>
   
-  <license>LGPL</license>
+  <license>Apache 2.0</license>
 
   <url type="website">http://ros.org/wiki/cob_android_settings</url>
 


### PR DESCRIPTION
no external contributors

do not merge before: **August, 4th 2017**
merge together with other `use license apache 2.0` PRs